### PR TITLE
Player info scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,18 @@ CBBpy requires Python >= 3.9 as well as the following packages:
 
 
 Install using pip:
-```
+```shell
 pip install cbbpy
 ```
 
 The men's and women's scrapers can be imported as such:
-```
+```python
 import cbbpy.mens_scraper as s
 import cbbpy.womens_scraper as s
 ```
 
 ## Functions available in CBBpy
-NOTE: game ID, as far as CBBpy is concernced, is a valid **ESPN** game ID
+NOTE: game ID, as far as CBBpy is concerned, is a valid **ESPN** game ID
 
 `s.get_game_info(game_id: str)` grabs all the metadata (game date, time, score, teams, referees, etc) for a particular game.
 
@@ -47,11 +47,13 @@ NOTE: game ID, as far as CBBpy is concernced, is a valid **ESPN** game ID
 
 `s.get_game_ids(date: Union[str, datetime])` returns a list of all game IDs for a particular date.
 
+`s.get_player_info(player_id: str)` returns a dataframe of one record describing the player info for that player
+
 ## Examples
 
 Function call: 
 
-```
+```python
 import cbbpy.mens_scraper as s
 s.get_game_info('401522202')
 ```
@@ -63,7 +65,7 @@ Returns:
 
 Function call: 
 
-```
+```python
 import cbbpy.womens_scraper as s 
 s.get_game_boxscore('401528028')
 ```
@@ -79,7 +81,7 @@ Returns (partially):
 
 Function call: 
 
-```
+```python
 import cbbpy.mens_scraper as s
 s.get_game_pbp('401522202')
 ```

--- a/src/cbbpy/cbbpy_utils.py
+++ b/src/cbbpy/cbbpy_utils.py
@@ -58,12 +58,14 @@ MENS_SCOREBOARD_URL = "https://www.espn.com/mens-college-basketball/scoreboard/_
 MENS_GAME_URL = "https://www.espn.com/mens-college-basketball/game/_/gameId/{}"
 MENS_BOXSCORE_URL = "https://www.espn.com/mens-college-basketball/boxscore/_/gameId/{}"
 MENS_PBP_URL = "https://www.espn.com/mens-college-basketball/playbyplay/_/gameId/{}"
+MENS_PLAYER_URL = "https://www.espn.com/mens-college-basketball/player/_/id/{}"
 WOMENS_SCOREBOARD_URL = "https://www.espn.com/womens-college-basketball/scoreboard/_/date/{}/seasontype/2/group/50"
 WOMENS_GAME_URL = "https://www.espn.com/womens-college-basketball/game/_/gameId/{}"
 WOMENS_BOXSCORE_URL = (
     "https://www.espn.com/womens-college-basketball/boxscore/_/gameId/{}"
 )
 WOMENS_PBP_URL = "https://www.espn.com/womens-college-basketball/playbyplay/_/gameId/{}"
+WOMENS_PLAYER_URL = "https://www.espn.com/womens-college-basketball/player/_/id/{}"
 NON_SHOT_TYPES = [
     "TV Timeout",
     "Jump Ball",
@@ -535,6 +537,72 @@ def _get_game_info(game_id, game_type):
     return df
 
 
+def _get_player(player_id, game_type):
+    """A function that scrapes a player's details.
+
+    Parameters:
+        - player_id: a string representing the players's ESPN ID
+        - game_type: which league we're scraping, "mens" or "womens"
+
+    Returns
+        - the game boxscore as a DataFrame
+    """
+    soup = None
+
+    if game_type == "mens":
+        pre_url = MENS_PLAYER_URL
+    else:
+        pre_url = WOMENS_PLAYER_URL
+
+    for i in range(ATTEMPTS):
+        try:
+            header = {
+                "User-Agent": str(np.random.choice(USER_AGENTS)),
+                "Referer": str(np.random.choice(REFERERS)),
+            }
+            url = pre_url.format(player_id)
+            page = r.get(url, headers=header)
+            soup = bs(page.content, "lxml")
+            raw_player = _get_player_from_soup(soup)
+
+            df = _get_player_details_helper(player_id, raw_player)
+
+        except Exception as ex:
+            if i + 1 == ATTEMPTS:
+                # max number of attempts reached, so return blank df
+                if soup is not None:
+                    if "Page not found." in soup.text:
+                        _log.error(
+                            f'"{time.ctime()}": {player_id} - player: Page not found error'
+                        )
+                        pnf_.append(game_id)
+                    elif "Page error" in soup.text:
+                        _log.error(
+                            f'"{time.ctime()}": {player_id} - player: Page error'
+                        )
+                    elif player is None:
+                        _log.error(
+                            f'"{time.ctime()}": {player_id} - player: Player JSON not found on page.'
+                        )
+                    else:
+                        _log.error(
+                            f'"{time.ctime()}": {player_id} - player: {ex}\n{traceback.format_exc()}'
+                        )
+                else:
+                    _log.error(
+                        f'"{time.ctime()}": {player_id} - player: GET error\n{ex}\n{traceback.format_exc()}'
+                    )
+                return pd.DataFrame([])
+            else:
+                # try again
+                time.sleep(2)
+                continue
+        else:
+            # no exception thrown
+            break
+
+    return df
+
 def _parse_date(date):
     parsed = False
 
@@ -549,7 +617,7 @@ def _parse_date(date):
 
     if not parsed:
         raise CouldNotParseError(
-            "The given date could not be parsed. Try any of these formats:\n"
+            f"The given date ({date}) could not be parsed. Try any of these formats:\n"
             + "Y-m-d\nY/m/d\nm-d-Y\nm/d/Y"
         )
 
@@ -1213,6 +1281,41 @@ def _get_game_info_helper(info, more_info, game_id, game_type):
     return pd.DataFrame([game_info_list], columns=game_info_cols)
 
 
+def _get_player_details_helper(player_id, info):
+    """A helper function that cleans a players's metadata.
+
+    Parameters:
+        - player_id: a string representing the player's ESPN player ID
+        - info: a JSON object containing player metadata
+
+    Returns
+        - the player metadata as a DataFrame
+    """
+
+    details = info['plyrHdr']['ath']
+    height = None
+    weight = None
+
+    if 'htwt' in details:
+        height, weight = details['htwt'].split(", ")
+
+    return pd.DataFrame.from_records([{
+        'player_id': player_id,
+        'display_name': details['dspNm'],
+        'display_number': details.get('dspNum'),
+        'first_name': details.get('fNm'),
+        'last_name': details.get('lNm'),
+        'pos': details.get('pos'),
+        'status': details.get('stsid'),
+        'team': details.get('tm'),
+        'experience': details.get('exp'),
+        'height': height,
+        'weight': weight,
+        'birthplace': details.get('brtpl'),
+        'date_of_birth': _parse_date(details['dobRaw']) if 'dobRaw' in details else None,
+    }])
+
+
 def _get_gamepackage_from_soup(soup):
     script_string = _find_json_in_content(soup)
 
@@ -1226,6 +1329,21 @@ def _get_gamepackage_from_soup(soup):
     gamepackage = jsn["page"]["content"]["gamepackage"]
 
     return gamepackage
+
+
+def _get_player_from_soup(soup):
+    script_string = _find_json_in_content(soup)
+
+    if script_string == "":
+        return None
+
+    pattern = re.compile(JSON_REGEX)
+    found = re.search(pattern, script_string).group(1)
+    js = "{" + found + "}"
+    jsn = json.loads(js)
+    player = jsn["page"]["content"]["player"]
+
+    return player
 
 
 def _get_scoreboard_from_soup(soup):

--- a/src/cbbpy/mens_scraper.py
+++ b/src/cbbpy/mens_scraper.py
@@ -15,6 +15,7 @@ from .cbbpy_utils import (
     _get_game_boxscore,
     _get_game_pbp,
     _get_game_info,
+    _get_player,
 )
 
 
@@ -126,3 +127,15 @@ def get_game_info(game_id: str) -> pd.DataFrame:
         - a DataFrame with one row and a column for each piece of metadata
     """
     return _get_game_info(game_id, "mens")
+
+
+def get_player_info(player_id: str) -> pd.DataFrame:
+    """A function that scrapes player info for a given player ID
+
+    Parameters:
+        - player_id: a string representing the player's ESPN player ID
+
+    Returns
+        - a DataFrame with one row for the player
+    """
+    return _get_player(player_id, "mens")

--- a/src/cbbpy/womens_scraper.py
+++ b/src/cbbpy/womens_scraper.py
@@ -15,6 +15,7 @@ from .cbbpy_utils import (
     _get_game_boxscore,
     _get_game_pbp,
     _get_game_info,
+    _get_player,
 )
 
 
@@ -126,3 +127,15 @@ def get_game_info(game_id: str) -> pd.DataFrame:
         - a DataFrame with one row and a column for each piece of metadata
     """
     return _get_game_info(game_id, "womens")
+
+
+def get_player_info(player_id: str) -> pd.DataFrame:
+    """A function that scrapes player info for a given player ID
+
+    Parameters:
+        - player_id: a string representing the player's ESPN player ID
+
+    Returns
+        - a DataFrame with one row for the player
+    """
+    return _get_player(player_id, "womens")


### PR DESCRIPTION
This adds a helper function for pulling in the player info for a given player id. Annoyingly, the PBPs from ESPN don't have player ids on them, and use full names, whereas the boxscores do have player ids on them, but use abbreviated names, so if you want to join the two you need to fetch this player info to get the full name for a player id. Yeesh.